### PR TITLE
Add -ignorefetcherrors to continue on fatal fetch errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,8 +9,9 @@ import (
 )
 
 type smugMugConf struct {
-	username    string
-	destination string
+	username          string
+	destination       string
+	ignorefetcherrors bool
 }
 
 func init() {
@@ -68,6 +69,7 @@ func parseArguments() *smugMugConf {
 
 	flag.StringVar(&conf.username, "user", "", "SmugMug user to backup")
 	flag.StringVar(&conf.destination, "destination", "", "Folder to save backup to")
+	flag.BoolVar(&conf.ignorefetcherrors, "ignorefetcherrors", false, "Ignore Smugmug API fetch errors")
 
 	flag.Parse()
 


### PR DESCRIPTION
Adds an option `-ignorefetcherrors` which allows the download to continue on fatal download issues.   I ran into issues when downloading my smugmug galleries and had hard failures on some images.    I added this option to relax the fetch allowing it to continue on error.

@tommyblue -- thanks for putting this utility together, it's been an awesome help to me.



