### PR TITLE
Build filenames based on conf templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 
 
+## [v1.1.0](https://github.com/tommyblue/smugmug-backup/tree/v1.1.0) - 2020-08-11
+
+### Added
+
+- `[store.file_names]` configuration added
+
 ## [v1.0.1](https://github.com/tommyblue/smugmug-backup/tree/v1.0.1) - 2020-08-10
 
 ### Maintenance

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Tommaso Visconti
+Copyright (c) 2020 Tommaso Visconti
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ user_secret = "<User Secret>"
 
 [store]
 destination = "<Backup destination folder>"
+file_names = "<Filename with template replacements>"
 ```
 
 All values can be overridden by environment variables, that have the following names:
@@ -45,19 +46,25 @@ SMGMG_BK_API_SECRET = "<API Secret>"
 SMGMG_BK_USER_TOKEN = "<User Token>"
 SMGMG_BK_USER_SECRET = "<User Secret>"
 SMGMG_BK_DESTINATION = "<Backup destination folder>"
+SMGMG_BK_FILE_NAMES = "<Filename with template replacements>"
 ```
 
 All configuration values are required. They can be omitted in the configuration file
 as long as they are overridden by environment values.
 
-The *username* can be found in the first part of the url in your SmugMug's homepage.  
+The **username** can be found in the first part of the url in your SmugMug's homepage.  
 In my case the url is [https://tommyblue.smugmug.com/](https://tommyblue.smugmug.com/) and the
 username is `tommyblue`.
 
-The *destination* is the local path to save SmugMug pictures and videos.  
+The **destination** is the local path to save SmugMug pictures and videos.  
 If the folder is not empty, then only new or changed files will be downloaded.
 
-*api_key*, *api_secret*, *user_token* and *user_secret* are the required credentials for
+**file_names** is a string including template replacements that will be used to build the file
+names for the files on disk. Accepted keys are `FileName`, `ImageKey`, `ArchivedMD5` and `UploadKey`
+and their values comes from the AlbumImage API response. If an invalid replacement is used,
+an error is returned. If the conf key is omitted or is empty, then `{{.FileName}}` is used.  
+
+**api_key**, **api_secret**, **user_token** and **user_secret** are the required credentials for
 authenticating with the SmugMug API.  
 See [credentials](#credentials) below for details about how to obtain them.
 

--- a/api.go
+++ b/api.go
@@ -55,6 +55,9 @@ func (w *Worker) albumImages(firstURI string, albumPath string) ([]albumImage, e
 		// Loop over response in inject the albumPath and then append to the images
 		for _, i := range a.Response.AlbumImage {
 			i.AlbumPath = albumPath
+			if err := i.buildFilename(w.filenameTmpl); err != nil {
+				return nil, fmt.Errorf("Cannot build image filename: %v", err)
+			}
 			images = append(images, i)
 		}
 		uri = a.Response.Pages.NextPage
@@ -90,14 +93,14 @@ func (w *Worker) saveImage(image albumImage, folder string) error {
 
 // saveVideo saves a video to the given folder unless its name is empty od is still under processing
 func (w *Worker) saveVideo(image albumImage, folder string) error {
-	if image.Processing { // Skip videos if under processing
-		return fmt.Errorf("Skipping video %s because under processing, %#v\n", image.Name(), image)
-	}
-
 	if image.Name() == "" {
 		return errors.New("Unable to find valid video filename, skipping..")
 	}
 	dest := fmt.Sprintf("%s/%s", folder, image.Name())
+
+	if image.Processing { // Skip videos if under processing
+		return fmt.Errorf("Skipping video %s because under processing, %#v\n", image.Name(), image)
+	}
 
 	var v albumVideo
 	log.Debug("Getting ", image.Uris.LargestVideo.Uri)

--- a/api_test.go
+++ b/api_test.go
@@ -47,8 +47,8 @@ func (c *albumImages) get(url string, obj interface{}) error {
 	defer func() { c.called++ }()
 	a := obj.(*albumImagesResponse)
 	a.Response.AlbumImage = []albumImage{
-		{},
-		{},
+		{FileName: "value"},
+		{FileName: "value"},
 	}
 	if c.called == 0 {
 		a.Response.Pages.NextPage = "something"
@@ -59,8 +59,10 @@ func (c *albumImages) get(url string, obj interface{}) error {
 }
 
 func TestGetAlbumImages(t *testing.T) {
+	tmpl, _ := buildFilenameTemplate("")
 	w := &Worker{
-		req: &albumImages{},
+		req:          &albumImages{},
+		filenameTmpl: tmpl,
 	}
 	albums, err := w.albumImages("someurl", "myAlbumPath")
 	if err != nil {

--- a/doc.go
+++ b/doc.go
@@ -47,6 +47,7 @@
 
 		[store]
 		destination = "<Backup destination folder>"
+		file_names = "{{.FileName}}
 
 	All values can be overridden by environment variables, that have the following names:
 
@@ -56,6 +57,7 @@
 		SMGMG_BK_USER_TOKEN = "<User Token>"
 		SMGMG_BK_USER_SECRET = "<User Secret>"
 		SMGMG_BK_DESTINATION = "<Backup destination folder>"
+		SMGMG_BK_FILE_NAMES = "<Backup destination folder>"
 
 	All configuration values are required. They can be omitted in the configuration file
 	as long as they are overridden by environment values.

--- a/json_structs_test.go
+++ b/json_structs_test.go
@@ -1,0 +1,97 @@
+package smugmug
+
+import (
+	"html/template"
+	"testing"
+)
+
+func Test_albumImage_buildFilename(t *testing.T) {
+	type fields struct {
+		FileName    string
+		ImageKey    string
+		ArchivedMD5 string
+		UploadKey   string
+	}
+
+	f := fields{
+		FileName:    "FileNameValue",
+		ImageKey:    "ImageKeyValue",
+		ArchivedMD5: "ArchivedMD5Value",
+		UploadKey:   "UploadKeyValue",
+	}
+
+	tests := []struct {
+		name         string
+		fields       fields
+		filenameConf string
+		want         string
+		wantErr      bool
+	}{
+		{
+			name:         "filename",
+			fields:       f,
+			filenameConf: "{{.FileName}}",
+			want:         "FileNameValue",
+			wantErr:      false,
+		},
+		{
+			name:         "empty",
+			fields:       f,
+			filenameConf: "",
+			want:         "",
+			wantErr:      true,
+		},
+		{
+			name:         "wrong",
+			fields:       f,
+			filenameConf: "{{.WrongKey}}",
+			want:         "",
+			wantErr:      true,
+		},
+		{
+			name:         "wrong with extra chars",
+			fields:       f,
+			filenameConf: "{{.WrongKey}}-",
+			want:         "-",
+			wantErr:      true,
+		},
+		{
+			name:         "complex",
+			fields:       f,
+			filenameConf: "{{.ImageKey}}-{{.FileName}}",
+			want:         "ImageKeyValue-FileNameValue",
+			wantErr:      false,
+		},
+		{
+			name:         "all",
+			fields:       f,
+			filenameConf: "prefix-{{.UploadKey}}/{{.ImageKey}}-{{.FileName}}_{{.ArchivedMD5}}",
+			want:         "prefix-UploadKeyValue/ImageKeyValue-FileNameValue_ArchivedMD5Value",
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &albumImage{
+				FileName:    tt.fields.FileName,
+				ImageKey:    tt.fields.ImageKey,
+				ArchivedMD5: tt.fields.ArchivedMD5,
+				UploadKey:   tt.fields.UploadKey,
+			}
+			tmpl, err := template.New("image_filename").Option("missingkey=error").Parse(tt.filenameConf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = a.buildFilename(tmpl)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error: %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err == nil && a.Name() != tt.want {
+				t.Fatalf("want: %s, got: %s", tt.want, a.Name())
+			}
+		})
+	}
+}

--- a/smugmug_test.go
+++ b/smugmug_test.go
@@ -75,6 +75,7 @@ func TestRun(t *testing.T) {
 	defer os.RemoveAll(dest_dir)
 
 	var downloadCalled int
+	tmpl, _ := buildFilenameTemplate("")
 	w := &Worker{
 		cfg: &Conf{
 			Username:    testUsername,
@@ -90,6 +91,7 @@ func TestRun(t *testing.T) {
 			downloadCalled++
 			return nil
 		},
+		filenameTmpl: tmpl,
 	}
 	w.Run()
 


### PR DESCRIPTION
#### :question: What

A new conf value permits to specify how the name of the files must be built using values from API AlbumImage response.

Configuration example:

```toml
[store]
file_names = "{{.ImageKey}}-{{.FileName}}"
```

Supported replacements are `FileName`, `ImageKey`, `ArchivedMD5` and `UploadKey`. If an invalid replacement is used, an error is returned.
If the conf key is omitted or is empty, then `{{.FileName}}` is used, which is equivalent at the behaviour without this PR.

The conf value can be overridden with the environment value `$SMGMG_BK_FILE_NAMES`

This PR will be marked as v1.1.0

#### :white_check_mark: Checklists

_This section contains a list of checklists for common uses, please delete the checklists that are useless for your current use case (or add another checklist if your use case isn't covered yet)._

##### Tests

- [ ] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [x] Have the changes in this PR been functionally tested?
- [x] Has `gofmt` been run on the code?
- [x] Have the changes been added to the `CHANGELOG.md` file?
