### PR TITLE
Set files chtimes when store.use_metadata_times is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- 
+- Add `store.use_metadata_times` and `store.force_metadata_times` confs to set files chtimes
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ user_secret = "<User Secret>"
 [store]
 destination = "<Backup destination folder>"
 file_names = "<Filename with template replacements>"
+use_metadata_times = true
+force_metadata_times = true
 ```
 
-All values can be overridden by environment variables, that have the following names:
+Some values can be overridden by environment variables, that have the following names:
 
 ```sh
 SMGMG_BK_API_KEY = "<API Key>"
@@ -57,6 +59,11 @@ If the folder is not empty, then only new or changed files will be downloaded.
 names for the files on disk. Accepted keys are `FileName`, `ImageKey`, `ArchivedMD5` and `UploadKey`
 and their values comes from the AlbumImage API response. If an invalid replacement is used,
 an error is returned. If the conf key is omitted or is empty, then `{{.FileName}}` is used.  
+
+When **use_metadata_times** is true, then the last modification timestamp of the objects will
+be set based on SmugMug metadata for newly downloaded files. Note that this option can require
+an additional API call for each image/video. If also **force_metadata_times** is true, then the
+timestamp is applied to all existing files.
 
 **api_key**, **api_secret**, **user_token** and **user_secret** are the required credentials for
 authenticating with the SmugMug API.  

--- a/json_structs.go
+++ b/json_structs.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"html/template"
+	"time"
 )
 
 type currentUser struct {
@@ -55,22 +56,34 @@ type albumImagesResponse struct {
 	} `json:"Response"`
 }
 
+type imageMetadataResponse struct {
+	Response struct {
+		DateTimeCreated  time.Time `json:"DateTimeCreated"`
+		DateTimeModified time.Time `json:"DateTimeModified"`
+	} `json:"Response"`
+}
+
 type albumImage struct {
-	AlbumPath    string // From album.URLPath
-	FileName     string `json:"FileName"`
-	ImageKey     string `json:"ImageKey"` // Use as unique ID if FileName is empty
-	ArchivedMD5  string `json:"ArchivedMD5"`
-	ArchivedSize int64  `json:"ArchivedSize"`
-	ArchivedUri  string `json:"ArchivedUri"`
-	IsVideo      bool   `json:"IsVideo"`
-	Processing   bool   `json:"Processing"`
-	UploadKey    string `json:"UploadKey"`
-	Uris         struct {
+	AlbumPath        string    // From album.URLPath
+	FileName         string    `json:"FileName"`
+	ImageKey         string    `json:"ImageKey"` // Use as unique ID if FileName is empty
+	ArchivedMD5      string    `json:"ArchivedMD5"`
+	ArchivedSize     int64     `json:"ArchivedSize"`
+	ArchivedUri      string    `json:"ArchivedUri"`
+	IsVideo          bool      `json:"IsVideo"`
+	Processing       bool      `json:"Processing"`
+	UploadKey        string    `json:"UploadKey"`
+	DateTimeOriginal time.Time `json:"DateTimeOriginal"`
+	Uris             struct {
+		ImageMetadata struct {
+			Uri string `json:"Uri"`
+		} `json:"ImageMetadata"`
 		LargestVideo struct {
 			Uri string `json:"Uri"`
 		} `json:"LargestVideo"`
 	} `json:"Uris"`
 
+	fileDatetime  time.Time
 	builtFilename string // The final filename, after template replacements
 }
 

--- a/smugmug_test.go
+++ b/smugmug_test.go
@@ -86,9 +86,9 @@ func TestRun(t *testing.T) {
 			albumURLPath:   albumURLPath,
 			albumImagesURI: albumImagesURI,
 		},
-		downloadFn: func(_, _ string, _ int64) error {
+		downloadFn: func(_, _ string, _ int64) (bool, error) {
 			downloadCalled++
-			return nil
+			return true, nil
 		},
 		filenameTmpl: tmpl,
 	}


### PR DESCRIPTION
#### :question: What

A new boolean configuration `store.use_metadata_times` tells the app, when true, to set modification time of the newly saved files to the original files date (retrieved from smugmug metadata API).

This doesn't apply to existing files unless `store.force_metadata_times` is used

Fixes #15

##### Tests

- [ ] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [x] Have the changes in this PR been functionally tested?
- [x] Has `gofmt` been run on the code?
- [x] Have the changes been added to the `CHANGELOG.md` file?
