### PR TITLE
Add feature to split extension from FileName.

### DIFF
--- a/json_structs_test.go
+++ b/json_structs_test.go
@@ -7,17 +7,19 @@ import (
 
 func Test_albumImage_buildFilename(t *testing.T) {
 	type fields struct {
-		FileName    string
-		ImageKey    string
-		ArchivedMD5 string
-		UploadKey   string
+		FileName                      string
+		ImageKey                      string
+		ArchivedMD5                   string
+		UploadKey                     string
+		PreferredDisplayFileExtension string
 	}
 
 	f := fields{
-		FileName:    "FileNameValue",
-		ImageKey:    "ImageKeyValue",
-		ArchivedMD5: "ArchivedMD5Value",
-		UploadKey:   "UploadKeyValue",
+		FileName:                      "FileNameValue",
+		ImageKey:                      "ImageKeyValue",
+		ArchivedMD5:                   "ArchivedMD5Value",
+		UploadKey:                     "UploadKeyValue",
+		PreferredDisplayFileExtension: "PreferredDisplayFileExtensionValue",
 	}
 
 	tests := []struct {
@@ -69,15 +71,68 @@ func Test_albumImage_buildFilename(t *testing.T) {
 			want:         "prefix-UploadKeyValue/ImageKeyValue-FileNameValue_ArchivedMD5Value",
 			wantErr:      false,
 		},
+		{
+			name: "extension manipulation - happy path",
+			fields: fields{
+				FileName:                      "FileNameValue.ExtenionInFileName",
+				ImageKey:                      "ImageKeyValue",
+				ArchivedMD5:                   "ArchivedMD5Value",
+				UploadKey:                     "UploadKeyValue",
+				PreferredDisplayFileExtension: "PreferredDisplayFileExtensionValue",
+			},
+			filenameConf: "{{.FileNameNoExt}}-{{.ImageKey}}.{{.Extension}}",
+			want:         "FileNameValue-ImageKeyValue.ExtenionInFileName",
+			wantErr:      false,
+		},
+		{
+			name: "extension manipulation - no extension in FileName",
+			fields: fields{
+				FileName:                      "FileNameValue",
+				ImageKey:                      "ImageKeyValue",
+				ArchivedMD5:                   "ArchivedMD5Value",
+				UploadKey:                     "UploadKeyValue",
+				PreferredDisplayFileExtension: "PreferredDisplayFileExtensionValue",
+			},
+			filenameConf: "{{.FileNameNoExt}}-{{.ImageKey}}.{{.Extension}}",
+			want:         "FileNameValue-ImageKeyValue.PreferredDisplayFileExtensionValue",
+			wantErr:      false,
+		},
+		{
+			name: "extension manipulation - last char is period",
+			fields: fields{
+				FileName:                      "FileNameValue.",
+				ImageKey:                      "ImageKeyValue",
+				ArchivedMD5:                   "ArchivedMD5Value",
+				UploadKey:                     "UploadKeyValue",
+				PreferredDisplayFileExtension: "PreferredDisplayFileExtensionValue",
+			},
+			filenameConf: "{{.FileNameNoExt}}-{{.ImageKey}}.{{.Extension}}",
+			want:         "FileNameValue-ImageKeyValue.",
+			wantErr:      false,
+		},
+		{
+			name: "extension manipulation - first char is period",
+			fields: fields{
+				FileName:                      ".HiddenFiles",
+				ImageKey:                      "ImageKeyValue",
+				ArchivedMD5:                   "ArchivedMD5Value",
+				UploadKey:                     "UploadKeyValue",
+				PreferredDisplayFileExtension: "PreferredDisplayFileExtensionValue",
+			},
+			filenameConf: "-{{.ImageKey}}.{{.Extension}}",
+			want:         "-ImageKeyValue.HiddenFiles",
+			wantErr:      true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &albumImage{
-				FileName:    tt.fields.FileName,
-				ImageKey:    tt.fields.ImageKey,
-				ArchivedMD5: tt.fields.ArchivedMD5,
-				UploadKey:   tt.fields.UploadKey,
+				FileName:                      tt.fields.FileName,
+				ImageKey:                      tt.fields.ImageKey,
+				ArchivedMD5:                   tt.fields.ArchivedMD5,
+				UploadKey:                     tt.fields.UploadKey,
+				PreferredDisplayFileExtension: tt.fields.PreferredDisplayFileExtension,
 			}
 			tmpl, err := template.New("image_filename").Option("missingkey=error").Parse(tt.filenameConf)
 			if err != nil {


### PR DESCRIPTION
#### :question: What

Allows you to split the extension from the FileName, so that you can set a unique value between the filename and the extension, such as:

FileName-ImageKey.jpg

As a result, images sort in standard lexicographic order by Filename but also maintain extensions.  This is useful when there are multiple images in the same gallery or folder with the same file name, and you want to keep all these images in the same folder on your backup.  Putting the ImageKey at the beginning of the template causes unordered arrangement of the images.  Putting the ImageKey at the end causes issues with applications that use the file extension. 

You could solve this with a separate folder per UploadKey as in the existing test scenario in json_structs_test.go but this particular solution allows you to keep the folder structure exactly as it appears in the SmugMug interface.

Updates to README and CHANGELOG pending acceptance.

#### :hammer: How to test

Tests updated.

#### :white_check_mark: Checklists

_This section contains a list of checklists for common uses, please delete the checklists that are useless for your current use case (or add another checklist if your use case isn't covered yet)._

##### Tests

- [X] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [X] Have the changes in this PR been functionally tested?
- [X] Has `gofmt` been run on the code?
- [ ] Have the changes been added to the `CHANGELOG.md` file?
- [ ] Update the README.md
