### PR TITLE
Bumps Go to 1.19.5 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ RUN sed -e "/deb-src/d" -i /etc/apt/sources.list \
     && rm -rf /.root/cache \
     && rm -rf /var/lib/apt/lists/*
 
-ADD https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz ./go.tar.gz
+ADD https://dl.google.com/go/go1.19.5.linux-amd64.tar.gz ./go.tar.gz
 
-RUN echo "b49fda1ca29a1946d6bb2a5a6982cf07ccd2aba849289508ee0f9918f6bb4552 go.tar.gz" | sha256sum -c - && \
+RUN echo "36519702ae2fd573c9869461990ae550c8c0d955cd28d2827a6b159fda81ff95 go.tar.gz" | sha256sum -c - && \
     tar -C /usr/local -xzf go.tar.gz && \
     rm ./go.tar.gz
 


### PR DESCRIPTION
#### :question: What

Gets the Docker build working again.

