### PR TITLE
[DRAFT] Download RAW files

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -63,6 +63,7 @@ func TestGetAlbumImages(t *testing.T) {
 	w := &Worker{
 		req:          &albumImages{},
 		filenameTmpl: tmpl,
+		cfg:          &Conf{},
 	}
 	albums, err := w.albumImages("someurl", "myAlbumPath")
 	if err != nil {

--- a/config.example.toml
+++ b/config.example.toml
@@ -13,3 +13,4 @@ write_csv = true
 force_video_download = true
 concurrent_albums = 5
 concurrent_downloads = 10
+download_raw = false

--- a/http.go
+++ b/http.go
@@ -115,7 +115,8 @@ func (s *handler) makeAPICall(url string) (*http.Response, error) {
 			{name: "Accept", value: "application/json"},
 			{name: "Authorization", value: h},
 		}
-		log.Debug(headers)
+		// Disable headers to avoid leaking sensitive information
+		// log.Debug(headers)
 		addHeaders(req, headers)
 
 		r, err := client.Do(req)

--- a/json_structs.go
+++ b/json_structs.go
@@ -88,6 +88,9 @@ type albumImage struct {
 		LargestVideo struct {
 			Uri string `json:"Uri"`
 		} `json:"LargestVideo"`
+		Components struct {
+			Uri string `json:"Uri"`
+		} `json:"Components"`
 	} `json:"Uris"`
 
 	builtFilename string // The final filename, after template replacements
@@ -131,5 +134,19 @@ type albumVideo struct {
 			Size int64  `json:"Size"`
 			Url  string `json:"Url"`
 		} `json:"LargestVideo"`
+	} `json:"Response"`
+}
+
+const componentTypeRaw = "svi"
+
+type imageComponent struct {
+	Response struct {
+		Component []struct {
+			ComponentType string `json:"ComponentType"`
+			DownloadUrl   string `json:"DownloadUrl"`
+			FileName      string `json:"FileName"`
+			FileSize      int64  `json:"FileSize"`
+			MD5           string `json:"MD5"`
+		} `json:"Component"`
 	} `json:"Response"`
 }

--- a/smugmug.go
+++ b/smugmug.go
@@ -26,6 +26,7 @@ type Conf struct {
 	ForceVideoDownload  bool   // When true, download videos also if marked as under processing
 	ConcurrentDownloads int    // number of concurrent downloads of images and videos, default is 1
 	ConcurrentAlbums    int    // number of concurrent albums analyzed via API calls
+	DownloadRaw         bool   // download raw files if available
 	HTTPBaseUrl         string // Smugmug API URL, defaults to https://api.smugmug.com
 	HTTPMaxRetries      int    // Max number of retries for HTTP calls, defaults to 3
 
@@ -134,6 +135,7 @@ func ReadConf(cfgPath string) (*Conf, error) {
 		ForceVideoDownload:  viper.GetBool("store.force_video_download"),
 		ConcurrentDownloads: viper.GetInt("store.concurrent_downloads"),
 		ConcurrentAlbums:    viper.GetInt("store.concurrent_albums"),
+		DownloadRaw:         viper.GetBool("store.download_raw"),
 		HTTPBaseUrl:         viper.GetString("http.base_url"),
 		HTTPMaxRetries:      viper.GetInt("http.max_retries"),
 	}
@@ -241,7 +243,6 @@ func (w *Worker) albumWorker(id int) {
 			}
 
 			log.Debugf("Got album images for %s", album.Uris.AlbumImages.URI)
-			// log.Debugf("%+v", images)
 			w.saveImages(images, folder)
 			if w.cfg.WriteCSV {
 				w.writeToCSV(images, folder)


### PR DESCRIPTION
#### :question: What

Adds a new boolean configuration option `download_raw` that enables Component lookup and the download of RAW files.

This is a blind PR because I don't have access to Source so I don't have any raw file to download 😅 

Fixes #61 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Album images now include enriched data by processing raw image components when enabled via a new configuration option.
  
- **Bug Fixes**
  - Improved data privacy by suppressing detailed HTTP header logs to prevent exposure of sensitive information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->